### PR TITLE
Add second solutions to days 2 & 3

### DIFF
--- a/docs/tutorials/day2.ipynb
+++ b/docs/tutorials/day2.ipynb
@@ -342,6 +342,61 @@
    "source": [
     "count_valids(text_input)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-12-03T11:30:28.536180Z",
+     "start_time": "2020-12-03T11:30:28.529243Z"
+    }
+   },
+   "source": [
+    "## Solution 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "valid_passwords = []\n",
+    "valid_passwords_part_two = []\n",
+    "\n",
+    "with open('./day-2-input.txt', 'r') as f:\n",
+    "    for l in f.readlines():\n",
+    "        # Parse line with regular expression\n",
+    "        n_min, n_max, letter, password = re.match(r\"(\\d+)-(\\d+) (\\w): (\\w+)\", l).groups()\n",
+    "        # Part one\n",
+    "        if int(n_min) <= len(re.findall(letter, password)) <= int(n_max):\n",
+    "            valid_passwords.append(password)\n",
+    "        # Part two, using Python's XOR operator\n",
+    "        if (password[int(n_min)-1] == letter) ^ (password[int(n_max)-1] == letter):\n",
+    "            valid_passwords_part_two.append(password)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Answer to part one\n",
+    "len(valid_passwords)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Answer to part two\n",
+    "len(valid_passwords_part_two)"
+   ]
   }
  ],
  "metadata": {
@@ -360,7 +415,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.7"
   },
   "toc": {
    "base_numbering": 1,
@@ -374,6 +429,35 @@
    "toc_position": {},
    "toc_section_display": true,
    "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/day3.ipynb
+++ b/docs/tutorials/day3.ipynb
@@ -451,6 +451,195 @@
    "source": [
     "solve_problem(text_input,(1,3))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Solution 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-12-03T11:23:09.529213Z",
+     "start_time": "2020-12-03T11:23:09.503784Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-12-03T11:24:00.482536Z",
+     "start_time": "2020-12-03T11:24:00.448545Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Load matrix from file\n",
+    "matrix = []\n",
+    "with open('inputs/day3.txt', 'r') as f:\n",
+    "    for l in f.readlines():\n",
+    "        matrix.append(\n",
+    "            # Parse each line as 0's and 1's\n",
+    "            list(map(int, list(l.strip().replace(\".\", \"0\").replace(\"#\", \"1\"))))\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-12-03T11:24:22.759144Z",
+     "start_time": "2020-12-03T11:24:22.728899Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Convert to Numpy array\n",
+    "matrix = np.array(matrix)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Part 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-12-03T11:27:59.939048Z",
+     "start_time": "2020-12-03T11:27:59.908879Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Repeat horizontally until enough columns (aspect ratio, rounded up at next integer)\n",
+    "matrix_reps = np.tile(matrix, (1, 1 + ( (3*matrix.shape[0]) // matrix.shape[1] )))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-12-03T11:28:00.804194Z",
+     "start_time": "2020-12-03T11:28:00.749103Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "193"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Use slices to select every 3rd column; diagonal corresponds to visited squares\n",
+    "matrix_reps[0::1, 0::3].diagonal().sum()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Part 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-12-03T11:28:36.839156Z",
+     "start_time": "2020-12-03T11:28:36.818993Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Generalising part one with a function\n",
+    "def check_slope(right, down):\n",
+    "    matrix_reps = np.tile(matrix, ( 1, 1 + ((right*matrix.shape[0]) // matrix.shape[1]) ))\n",
+    "    return matrix_reps[0::down, 0::right].diagonal().sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-12-03T11:28:44.593983Z",
+     "start_time": "2020-12-03T11:28:44.574015Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "slopes = [\n",
+    "    (1, 1),\n",
+    "    (3, 1),\n",
+    "    (5, 1),\n",
+    "    (7, 1),\n",
+    "    (1, 2)\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-12-03T11:28:50.899137Z",
+     "start_time": "2020-12-03T11:28:50.873590Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Count the trees encountered with each slope. Cast as uint64 to avoid overflow when calling np.product\n",
+    "trees = np.array([check_slope(r, d) for r, d in slopes], dtype='uint64')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-12-03T11:28:56.943881Z",
+     "start_time": "2020-12-03T11:28:56.923812Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1355323200"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.product(trees)"
+   ]
   }
  ],
  "metadata": {
@@ -469,7 +658,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.7"
   },
   "toc": {
    "base_numbering": 1,
@@ -483,6 +672,35 @@
    "toc_position": {},
    "toc_section_display": true,
    "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Here are some solutions of my own 😉

Day 2:
```python
import re

valid_passwords = []
valid_passwords_part_two = []

with open('./day-2-input.txt', 'r') as f:
    for l in f.readlines():
        # Parse line
        n_min, n_max, letter, password = re.match(r"(\d+)-(\d+) (\w): (\w+)", l).groups()
        # Part one
        if int(n_min) <= len(re.findall(letter, password)) <= int(n_max):
            valid_passwords.append(password)
        # Part two
        if (password[int(n_min)-1] == letter) ^ (password[int(n_max)-1] == letter):
            valid_passwords_part_two.append(password)
```

Day3:
```python
import numpy as np

matrix = []

with open('./day-3-input.txt', 'r') as f:
    for l in f.readlines():
        matrix.append(
            # Parse each line as 0's and 1's
            list(map(int, list(l.strip().replace(".", "0").replace("#", "1"))))
        )

matrix = np.array(matrix)

# Repeat horizontally until enough columns
matrix_reps = np.tile(matrix, ( 1, 1 + ((3*matrix.shape[0]) // matrix.shape[1]) ))

# Answer to part one
matrix_reps[0::1, 0::3].diagonal().sum()

# Generalising port one with a function
def check_slope(right, down):
    matrix_reps = np.tile(matrix, ( 1, 1 + ((right*matrix.shape[0]) // matrix.shape[1]) ))
    return matrix_reps[0::down, 0::right].diagonal().sum()

slopes = [
    (1, 1),
    (3, 1),
    (5, 1),
    (7, 1),
    (1, 2)
]

# Count the trees encountered with each slope. Cast as uint64 to avoid overflow when calling np.product
trees = np.array([check_slope(r, d) for r, d in slopes], dtype='uint64')
np.product(trees)
```